### PR TITLE
Fix REST-API / Swagger Error:

### DIFF
--- a/Api/Data/GiftRuleDataInterface.php
+++ b/Api/Data/GiftRuleDataInterface.php
@@ -97,7 +97,7 @@ interface GiftRuleDataInterface
     /**
      * Get the code.
      *
-     * @return array
+     * @return mixed[]
      * [
      *     {product_id} => {qty}
      *     ...
@@ -117,7 +117,7 @@ interface GiftRuleDataInterface
     /**
      * Get the code.
      *
-     * @return array
+     * @return mixed[]
      * [
      *     {product_id} => [ {product_data} ]
      *     ...

--- a/Api/Data/GiftRuleInterface.php
+++ b/Api/Data/GiftRuleInterface.php
@@ -51,7 +51,7 @@ interface GiftRuleInterface
     /**
      * Get the price range.
      *
-     * @return decimal
+     * @return float
      */
     public function getPriceRange();
 

--- a/Api/Data/GiftRuleSearchResultsInterface.php
+++ b/Api/Data/GiftRuleSearchResultsInterface.php
@@ -27,7 +27,7 @@ interface GiftRuleSearchResultsInterface extends SearchResultsInterface
     /**
      * Get giftrule items.
      *
-     * @return GiftRuleInterface
+     * @return \Smile\GiftSalesRule\Api\Data\GiftRuleInterface
      */
     public function getItems();
 

--- a/Api/GiftRuleRepositoryInterface.php
+++ b/Api/GiftRuleRepositoryInterface.php
@@ -30,7 +30,7 @@ interface GiftRuleRepositoryInterface
      * Get a giftrule by ID.
      *
      * @param int $entityId Entity id
-     * @return GiftRuleInterface
+     * @return \Smile\GiftSalesRule\Api\Data\GiftRuleInterface
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function getById($entityId);
@@ -39,7 +39,7 @@ interface GiftRuleRepositoryInterface
      * Get the giftrules matching the specified criteria.
      *
      * @param SearchCriteriaInterface $searchCriteria Search criteria
-     * @return GiftRuleSearchResultsInterface
+     * @return \Smile\GiftSalesRule\Api\Data\GiftRuleSearchResultsInterface
      */
     public function getList(SearchCriteriaInterface $searchCriteria = null);
 
@@ -47,7 +47,7 @@ interface GiftRuleRepositoryInterface
      * Save the GiftRule.
      *
      * @param GiftRuleInterface $giftRule Gift rule
-     * @return GiftRuleInterface
+     * @return \Smile\GiftSalesRule\Api\Data\GiftRuleInterface
      * @throws \Magento\Framework\Exception\CouldNotSaveException
      */
     public function save(GiftRuleInterface $giftRule);

--- a/Api/GiftRuleServiceInterface.php
+++ b/Api/GiftRuleServiceInterface.php
@@ -29,7 +29,7 @@ interface GiftRuleServiceInterface
      *
      * @param Quote $quote Quote
      *
-     * @return array
+     * @return mixed[]
      *     {gift_rule_id} => [
      *         maximum_number_product => {number}
      *         code => {gift_rule_code}


### PR DESCRIPTION
The "array" class doesn't exist and the namespace must be specified...
The "decimal" class doesn't exist and the namespace must be specified...
The "GiftRuleInterface" class doesn't exist and the namespace must be specified...
The "GiftRuleSearchResultsInterface" class doesn't exist and the namespace must be specified...