### PR TITLE
[ValueProviderPlugin] Fix accessing array offset on value of type null

### DIFF
--- a/Plugin/Model/Rule/Metadata/ValueProviderPlugin.php
+++ b/Plugin/Model/Rule/Metadata/ValueProviderPlugin.php
@@ -73,6 +73,10 @@ class ValueProviderPlugin
     ) {
         $extensionAttributes = $rule->getExtensionAttributes();
 
+        if  (empty($extensionAttributes)) {
+            return $result;
+        }
+
         $result['actions']['children']['simple_action']['arguments']['data']['config']['options'][] = [
             'label' => __('to offer product'),
             'value' => GiftRuleInterface::OFFER_PRODUCT,


### PR DESCRIPTION
When the cart price rule is being created initially, extension attributes are empty.
This leads to PHP notice entry in logs. This commit fixes this issue.